### PR TITLE
fix: the initialize of repository item icon as using FaIcon

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ I adopt MVVM like a native app as Flutter architecture. This architecture follow
     </tr>
     <tr>
         <td><img width=300 src="https://github.com/shusuke0812/flutter-engineer-codecheck/assets/33107697/9b71e965-bd90-486d-8d67-0c1376e97ed9"></td>
-        <td><img width=300 src="https://github.com/shusuke0812/flutter-engineer-codecheck/assets/33107697/a5f3bcec-b79e-45c0-ac48-cfba6097d514"></td>
+        <td><img width=300 src="https://github.com/shusuke0812/flutter-engineer-codecheck/assets/33107697/6bc8be48-874e-40e9-b1e3-fef0d753bd11"></td>
     </tr>
 </table>
 

--- a/github_search/lib/presentation/github_repository_detail_screen/widget/repository_item_icon_widget.dart
+++ b/github_search/lib/presentation/github_repository_detail_screen/widget/repository_item_icon_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:github_search/presentation/github_repository_detail_screen/model/repository_item_icon.dart';
 
 class RepositoryItemIconWidget extends StatelessWidget {
@@ -13,6 +14,7 @@ class RepositoryItemIconWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       alignment: Alignment.center,
+      clipBehavior: Clip.antiAlias,
       children: [
         Container(
           alignment: Alignment.center,
@@ -23,7 +25,7 @@ class RepositoryItemIconWidget extends StatelessWidget {
             borderRadius: BorderRadius.circular(6),
           ),
         ),
-        Icon(
+        FaIcon(
           icon.icon, 
           size: 15, 
           color: Colors.white

--- a/github_search/lib/presentation/github_repository_detail_screen/widget/repository_item_icon_widget.dart
+++ b/github_search/lib/presentation/github_repository_detail_screen/widget/repository_item_icon_widget.dart
@@ -18,8 +18,8 @@ class RepositoryItemIconWidget extends StatelessWidget {
       children: [
         Container(
           alignment: Alignment.center,
-          width: 25,
-          height: 25,
+          width: 24,
+          height: 24,
           decoration: BoxDecoration(
             color: icon.color,
             borderRadius: BorderRadius.circular(6),
@@ -27,7 +27,7 @@ class RepositoryItemIconWidget extends StatelessWidget {
         ),
         FaIcon(
           icon.icon, 
-          size: 15, 
+          size: 12, 
           color: Colors.white
         )
       ],


### PR DESCRIPTION
## Purpose
<!-- _Describe the problem or feature in addition to a link to the issues._ -->

The repository item icon are not center in the container.

<table>
    <tr>
        <td><img width=300 src="https://github.com/shusuke0812/flutter-engineer-codecheck/assets/33107697/3f24662d-7cd8-4412-9cf0-f982a4d50eb8"></td>
        <td><img width=300 src="https://github.com/shusuke0812/flutter-engineer-codecheck/assets/33107697/83d6bdaa-fd1f-4dbd-a2e5-2d3bb0ea8d60"></td>
    </tr>
</table>


## Approach
<!-- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
- [x] Not using Icon but FaIcon. Followed `font_awesome_flutter` package usage. ([doc](https://github.com/fluttercommunity/font_awesome_flutter#usage))
- [x] Adjust container and icon size

## Learning
<!-- _Describe the research stage_ -->

<!-- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->

#### Blog Posts
- [stack-overflow : How to use same size for Material Icons and Font Awesome Icons in Flutter?](https://stackoverflow.com/questions/62189248/how-to-use-same-size-for-material-icons-and-font-awesome-icons-in-flutter)
