### PR TITLE
fix: wrong watchers count

### DIFF
--- a/github_search/lib/entity/github_repository.dart
+++ b/github_search/lib/entity/github_repository.dart
@@ -53,3 +53,12 @@ extension GitHubRepositoryExtension on GitHubRepository {
     return toWithSeparated(issueCount);
   }
 }
+
+@freezed
+class GitHubGetRepository with _$GitHubGetRepository {
+  const factory GitHubGetRepository({
+    @JsonKey(name: 'subscribers_count') required String subscribersCount
+  }) = _GitHubGetRepository;
+
+  factory GitHubGetRepository.fromJson(Map<String, dynamic> json) => _$GitHubGetRepositoryFromJson(json);
+}

--- a/github_search/lib/entity/github_repository.dart
+++ b/github_search/lib/entity/github_repository.dart
@@ -33,19 +33,19 @@ class GitHubRepository with _$GitHubRepository {
 
 extension GitHubRepositoryExtension on GitHubRepository {
   String get starCountWithComma {
-    return _toWithSeparated(starCount);
+    return _toWithSeparatedComma(starCount);
   }
 
   String get watchCountWithComma {
-    return _toWithSeparated(watchCount);
+    return _toWithSeparatedComma(watchCount);
   }
 
   String get forkCountWithComma {
-    return _toWithSeparated(forkCount);
+    return _toWithSeparatedComma(forkCount);
   }
 
   String get issueCountWithComma {
-    return _toWithSeparated(issueCount);
+    return _toWithSeparatedComma(issueCount);
   }
 }
 
@@ -60,11 +60,11 @@ class GitHubGetRepository with _$GitHubGetRepository {
 
 extension GitHubGetRepositoryExtension on GitHubGetRepository {
   String get subscribersCountWithComma {
-    return _toWithSeparated(subscribersCount);
+    return _toWithSeparatedComma(subscribersCount);
   }
 }
 
-String _toWithSeparated(int value) {
+String _toWithSeparatedComma(int value) {
   final formatter = NumberFormat("#,###");
   return formatter.format(value);
 }

--- a/github_search/lib/entity/github_repository.dart
+++ b/github_search/lib/entity/github_repository.dart
@@ -32,33 +32,39 @@ class GitHubRepository with _$GitHubRepository {
 }
 
 extension GitHubRepositoryExtension on GitHubRepository {
-  String toWithSeparated(int value) {
-    final formatter = NumberFormat("#,###");
-    return formatter.format(value);
-  }
-
   String get starCountWithComma {
-    return toWithSeparated(starCount);
+    return _toWithSeparated(starCount);
   }
 
   String get watchCountWithComma {
-    return toWithSeparated(watchCount);
+    return _toWithSeparated(watchCount);
   }
 
   String get forkCountWithComma {
-    return toWithSeparated(forkCount);
+    return _toWithSeparated(forkCount);
   }
 
   String get issueCountWithComma {
-    return toWithSeparated(issueCount);
+    return _toWithSeparated(issueCount);
   }
 }
 
 @freezed
 class GitHubGetRepository with _$GitHubGetRepository {
   const factory GitHubGetRepository({
-    @JsonKey(name: 'subscribers_count') required String subscribersCount
+    @JsonKey(name: 'subscribers_count') required int subscribersCount
   }) = _GitHubGetRepository;
 
   factory GitHubGetRepository.fromJson(Map<String, dynamic> json) => _$GitHubGetRepositoryFromJson(json);
+}
+
+extension GitHubGetRepositoryExtension on GitHubGetRepository {
+  String get subscribersCountWithComma {
+    return _toWithSeparated(subscribersCount);
+  }
+}
+
+String _toWithSeparated(int value) {
+  final formatter = NumberFormat("#,###");
+  return formatter.format(value);
 }

--- a/github_search/lib/entity/github_repository.dart
+++ b/github_search/lib/entity/github_repository.dart
@@ -7,6 +7,11 @@ import 'github_license.dart';
 part 'github_repository.freezed.dart';
 part 'github_repository.g.dart';
 
+// NOTE: 
+// Watch count is Incorrect value. 🔥
+// Must use `subscribers_count` of Get a repository API. 
+// Ref is here. (https://github.com/octokit/octokit.net/issues/1510)
+
 @freezed
 class GitHubRepository with _$GitHubRepository {
   const factory GitHubRepository({

--- a/github_search/lib/entity/github_repository.freezed.dart
+++ b/github_search/lib/entity/github_repository.freezed.dart
@@ -423,3 +423,147 @@ abstract class _GitHubRepository implements GitHubRepository {
   _$$_GitHubRepositoryCopyWith<_$_GitHubRepository> get copyWith =>
       throw _privateConstructorUsedError;
 }
+
+GitHubGetRepository _$GitHubGetRepositoryFromJson(Map<String, dynamic> json) {
+  return _GitHubGetRepository.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GitHubGetRepository {
+  @JsonKey(name: 'subscribers_count')
+  String get subscribersCount => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GitHubGetRepositoryCopyWith<GitHubGetRepository> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GitHubGetRepositoryCopyWith<$Res> {
+  factory $GitHubGetRepositoryCopyWith(
+          GitHubGetRepository value, $Res Function(GitHubGetRepository) then) =
+      _$GitHubGetRepositoryCopyWithImpl<$Res, GitHubGetRepository>;
+  @useResult
+  $Res call({@JsonKey(name: 'subscribers_count') String subscribersCount});
+}
+
+/// @nodoc
+class _$GitHubGetRepositoryCopyWithImpl<$Res, $Val extends GitHubGetRepository>
+    implements $GitHubGetRepositoryCopyWith<$Res> {
+  _$GitHubGetRepositoryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? subscribersCount = null,
+  }) {
+    return _then(_value.copyWith(
+      subscribersCount: null == subscribersCount
+          ? _value.subscribersCount
+          : subscribersCount // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_GitHubGetRepositoryCopyWith<$Res>
+    implements $GitHubGetRepositoryCopyWith<$Res> {
+  factory _$$_GitHubGetRepositoryCopyWith(_$_GitHubGetRepository value,
+          $Res Function(_$_GitHubGetRepository) then) =
+      __$$_GitHubGetRepositoryCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'subscribers_count') String subscribersCount});
+}
+
+/// @nodoc
+class __$$_GitHubGetRepositoryCopyWithImpl<$Res>
+    extends _$GitHubGetRepositoryCopyWithImpl<$Res, _$_GitHubGetRepository>
+    implements _$$_GitHubGetRepositoryCopyWith<$Res> {
+  __$$_GitHubGetRepositoryCopyWithImpl(_$_GitHubGetRepository _value,
+      $Res Function(_$_GitHubGetRepository) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? subscribersCount = null,
+  }) {
+    return _then(_$_GitHubGetRepository(
+      subscribersCount: null == subscribersCount
+          ? _value.subscribersCount
+          : subscribersCount // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_GitHubGetRepository implements _GitHubGetRepository {
+  const _$_GitHubGetRepository(
+      {@JsonKey(name: 'subscribers_count') required this.subscribersCount});
+
+  factory _$_GitHubGetRepository.fromJson(Map<String, dynamic> json) =>
+      _$$_GitHubGetRepositoryFromJson(json);
+
+  @override
+  @JsonKey(name: 'subscribers_count')
+  final String subscribersCount;
+
+  @override
+  String toString() {
+    return 'GitHubGetRepository(subscribersCount: $subscribersCount)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_GitHubGetRepository &&
+            (identical(other.subscribersCount, subscribersCount) ||
+                other.subscribersCount == subscribersCount));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, subscribersCount);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_GitHubGetRepositoryCopyWith<_$_GitHubGetRepository> get copyWith =>
+      __$$_GitHubGetRepositoryCopyWithImpl<_$_GitHubGetRepository>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_GitHubGetRepositoryToJson(
+      this,
+    );
+  }
+}
+
+abstract class _GitHubGetRepository implements GitHubGetRepository {
+  const factory _GitHubGetRepository(
+      {@JsonKey(name: 'subscribers_count')
+      required final String subscribersCount}) = _$_GitHubGetRepository;
+
+  factory _GitHubGetRepository.fromJson(Map<String, dynamic> json) =
+      _$_GitHubGetRepository.fromJson;
+
+  @override
+  @JsonKey(name: 'subscribers_count')
+  String get subscribersCount;
+  @override
+  @JsonKey(ignore: true)
+  _$$_GitHubGetRepositoryCopyWith<_$_GitHubGetRepository> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/github_search/lib/entity/github_repository.freezed.dart
+++ b/github_search/lib/entity/github_repository.freezed.dart
@@ -431,7 +431,7 @@ GitHubGetRepository _$GitHubGetRepositoryFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$GitHubGetRepository {
   @JsonKey(name: 'subscribers_count')
-  String get subscribersCount => throw _privateConstructorUsedError;
+  int get subscribersCount => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -445,7 +445,7 @@ abstract class $GitHubGetRepositoryCopyWith<$Res> {
           GitHubGetRepository value, $Res Function(GitHubGetRepository) then) =
       _$GitHubGetRepositoryCopyWithImpl<$Res, GitHubGetRepository>;
   @useResult
-  $Res call({@JsonKey(name: 'subscribers_count') String subscribersCount});
+  $Res call({@JsonKey(name: 'subscribers_count') int subscribersCount});
 }
 
 /// @nodoc
@@ -467,7 +467,7 @@ class _$GitHubGetRepositoryCopyWithImpl<$Res, $Val extends GitHubGetRepository>
       subscribersCount: null == subscribersCount
           ? _value.subscribersCount
           : subscribersCount // ignore: cast_nullable_to_non_nullable
-              as String,
+              as int,
     ) as $Val);
   }
 }
@@ -480,7 +480,7 @@ abstract class _$$_GitHubGetRepositoryCopyWith<$Res>
       __$$_GitHubGetRepositoryCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({@JsonKey(name: 'subscribers_count') String subscribersCount});
+  $Res call({@JsonKey(name: 'subscribers_count') int subscribersCount});
 }
 
 /// @nodoc
@@ -500,7 +500,7 @@ class __$$_GitHubGetRepositoryCopyWithImpl<$Res>
       subscribersCount: null == subscribersCount
           ? _value.subscribersCount
           : subscribersCount // ignore: cast_nullable_to_non_nullable
-              as String,
+              as int,
     ));
   }
 }
@@ -516,7 +516,7 @@ class _$_GitHubGetRepository implements _GitHubGetRepository {
 
   @override
   @JsonKey(name: 'subscribers_count')
-  final String subscribersCount;
+  final int subscribersCount;
 
   @override
   String toString() {
@@ -554,14 +554,14 @@ class _$_GitHubGetRepository implements _GitHubGetRepository {
 abstract class _GitHubGetRepository implements GitHubGetRepository {
   const factory _GitHubGetRepository(
       {@JsonKey(name: 'subscribers_count')
-      required final String subscribersCount}) = _$_GitHubGetRepository;
+      required final int subscribersCount}) = _$_GitHubGetRepository;
 
   factory _GitHubGetRepository.fromJson(Map<String, dynamic> json) =
       _$_GitHubGetRepository.fromJson;
 
   @override
   @JsonKey(name: 'subscribers_count')
-  String get subscribersCount;
+  int get subscribersCount;
   @override
   @JsonKey(ignore: true)
   _$$_GitHubGetRepositoryCopyWith<_$_GitHubGetRepository> get copyWith =>

--- a/github_search/lib/entity/github_repository.g.dart
+++ b/github_search/lib/entity/github_repository.g.dart
@@ -39,3 +39,15 @@ Map<String, dynamic> _$$_GitHubRepositoryToJson(_$_GitHubRepository instance) =>
       'owner': instance.owner,
       'license': instance.license,
     };
+
+_$_GitHubGetRepository _$$_GitHubGetRepositoryFromJson(
+        Map<String, dynamic> json) =>
+    _$_GitHubGetRepository(
+      subscribersCount: json['subscribers_count'] as String,
+    );
+
+Map<String, dynamic> _$$_GitHubGetRepositoryToJson(
+        _$_GitHubGetRepository instance) =>
+    <String, dynamic>{
+      'subscribers_count': instance.subscribersCount,
+    };

--- a/github_search/lib/entity/github_repository.g.dart
+++ b/github_search/lib/entity/github_repository.g.dart
@@ -43,7 +43,7 @@ Map<String, dynamic> _$$_GitHubRepositoryToJson(_$_GitHubRepository instance) =>
 _$_GitHubGetRepository _$$_GitHubGetRepositoryFromJson(
         Map<String, dynamic> json) =>
     _$_GitHubGetRepository(
-      subscribersCount: json['subscribers_count'] as String,
+      subscribersCount: json['subscribers_count'] as int,
     );
 
 Map<String, dynamic> _$$_GitHubGetRepositoryToJson(

--- a/github_search/lib/main.dart
+++ b/github_search/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:github_search/presentation/github_repository_detail_screen/github_repository_detail_viewmodel.dart';
 import 'package:github_search/presentation/github_search_screen/github_search_viewmodel.dart';
 import 'package:github_search/repository/github_readme_repository.dart';
+import 'package:github_search/repository/github_repo_repository.dart';
 import 'package:github_search/repository/github_search_repository.dart';
 import 'package:github_search/utility/router/router.dart';
 import 'package:provider/provider.dart';
@@ -18,7 +19,7 @@ class MyApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider.value(value: GitHubSearchViewModel(githubSearchRepository: GitHubSearchRepository())),
-        ChangeNotifierProvider.value(value: GitHubRepositoryDetailViewModel(githubReadmeRepository: GitHubReadmeRepository()))
+        ChangeNotifierProvider.value(value: GitHubRepositoryDetailViewModel(githubReadmeRepository: GitHubReadmeRepository(), gitHubRepoRepository: GitHubRepoRepository()))
       ],
       child: MaterialApp.router(
         routerDelegate: appRouter.routerDelegate,

--- a/github_search/lib/presentation/github_repository_detail_screen/github_repository_detail_view.dart
+++ b/github_search/lib/presentation/github_repository_detail_screen/github_repository_detail_view.dart
@@ -28,6 +28,12 @@ class _GitHubRepisitoryDetailViewState extends State<GitHubRepisitoryDetailView>
       widget.repository.owner?.login ?? "", widget.repository.name
     );
   }
+
+  Future<void> _loadSubscribersCount() async {
+    await Provider.of<GitHubRepositoryDetailViewModel>(context, listen: false).loadSubscribersCount(
+      widget.repository.fullName
+    );
+  }
   
   @override
   Widget build(BuildContext context) {
@@ -48,7 +54,15 @@ class _GitHubRepisitoryDetailViewState extends State<GitHubRepisitoryDetailView>
                 },
               ),
               const SizedBox(height: 20),
-              RepositoryDetailBodyWidget(repository: widget.repository),
+              FutureBuilder(
+                future: _loadSubscribersCount(),
+                builder: (context, snapshot) {
+                  return RepositoryDetailBodyWidget(
+                    repository: widget.repository,
+                    getRepository: Provider.of<GitHubRepositoryDetailViewModel>(context).getRepository,
+                  );
+                }
+              ),
               const SizedBox(height: 20),
               FutureBuilder(
                 future: _loadReadmeUrl(),

--- a/github_search/lib/presentation/github_repository_detail_screen/github_repository_detail_viewmodel.dart
+++ b/github_search/lib/presentation/github_repository_detail_screen/github_repository_detail_viewmodel.dart
@@ -1,16 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:github_search/entity/github_repository.dart';
 import 'package:github_search/repository/github_readme_repository.dart';
+import 'package:github_search/repository/github_repo_repository.dart';
 import 'package:github_search/utility/logger.dart';
 
 class GitHubRepositoryDetailViewModel with ChangeNotifier {
-  GitHubRepositoryDetailViewModel({required this.githubReadmeRepository});
+  GitHubRepositoryDetailViewModel({
+    required this.githubReadmeRepository,
+    required this.gitHubRepoRepository
+  });
 
   final GitHubReadmeRepository githubReadmeRepository;
+  final GitHubRepoRepository gitHubRepoRepository;
 
   // Success notify values
   String _htmlUrl = "https://flutter.dev/";
   String get htmlUrl {
     return _htmlUrl;
+  }
+
+  GitHubGetRepository? _getRepository;
+  GitHubGetRepository? get getRepository {
+    return _getRepository;
   }
 
   // Error notifiy values
@@ -33,6 +44,23 @@ class GitHubRepositoryDetailViewModel with ChangeNotifier {
         _errorMessage = "Not found README";
         notifyListeners();
       }, 
+      exception: (exception) {
+        // do nothing
+      }
+    );
+  }
+
+  Future<void> loadSubscribersCount(String fullName) async {
+    final result = await gitHubRepoRepository.getRepository(fullName: fullName);
+    result.when(
+      success: (data) {
+        _getRepository = data;
+        notifyListeners();
+      },
+      error: (error) {
+        _errorMessage = "Not found subscribers count";
+        notifyListeners();
+      },
       exception: (exception) {
         // do nothing
       }

--- a/github_search/lib/presentation/github_repository_detail_screen/widget/repository_detail_body_item_widget.dart
+++ b/github_search/lib/presentation/github_repository_detail_screen/widget/repository_detail_body_item_widget.dart
@@ -10,9 +10,11 @@ class RepositoryDetailBodyItemWidget extends StatelessWidget {
     super.key,
     required this.repository,
     required this.icon,
+    required this.getRepository
   });
 
   final GitHubRepository repository;
+  final GitHubGetRepository? getRepository;
   final RepositoryItemIcon icon;
 
   Widget countText(RepositoryItemIcon icon) {
@@ -20,7 +22,7 @@ class RepositoryDetailBodyItemWidget extends StatelessWidget {
       case RepositoryItemIcon.stars:
         return Text(repository.starCountWithComma);
       case RepositoryItemIcon.watchers:
-        return Text(repository.watchCountWithComma);
+        return Text(getRepository?.subscribersCountWithComma ?? "0");
       case RepositoryItemIcon.forks:
         return Text(repository.forkCountWithComma);
       case RepositoryItemIcon.issues:

--- a/github_search/lib/presentation/github_repository_detail_screen/widget/repository_detail_body_item_widget.dart
+++ b/github_search/lib/presentation/github_repository_detail_screen/widget/repository_detail_body_item_widget.dart
@@ -22,7 +22,7 @@ class RepositoryDetailBodyItemWidget extends StatelessWidget {
       case RepositoryItemIcon.stars:
         return Text(repository.starCountWithComma);
       case RepositoryItemIcon.watchers:
-        return Text(getRepository?.subscribersCountWithComma ?? "0");
+        return Text(getRepository?.subscribersCountWithComma ?? "-");
       case RepositoryItemIcon.forks:
         return Text(repository.forkCountWithComma);
       case RepositoryItemIcon.issues:

--- a/github_search/lib/presentation/github_repository_detail_screen/widget/repository_detail_body_widget.dart
+++ b/github_search/lib/presentation/github_repository_detail_screen/widget/repository_detail_body_widget.dart
@@ -6,10 +6,12 @@ import 'package:github_search/presentation/github_repository_detail_screen/widge
 class RepositoryDetailBodyWidget extends StatelessWidget {
   const RepositoryDetailBodyWidget({
     super.key,
-    required this.repository
+    required this.repository,
+    required this.getRepository
   });
 
   final GitHubRepository repository;
+  final GitHubGetRepository? getRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -32,6 +34,7 @@ class RepositoryDetailBodyWidget extends StatelessWidget {
               child: RepositoryDetailBodyItemWidget(
                 icon: RepositoryItemIcon.values[index],
                 repository: repository,
+                getRepository: getRepository,
               ),
             ),
             );

--- a/github_search/lib/repository/github_repo_repository.dart
+++ b/github_search/lib/repository/github_repo_repository.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+
+import 'package:github_search/entity/github_repository.dart';
+import 'package:github_search/repository/network/request/get_repository_request.dart';
+import 'package:github_search/repository/network/result.dart';
+import 'package:github_search/repository/network/api_service.dart';
+
+// Interface
+
+abstract class GitHubRepoRepositoryInterface {
+  Future<Result<GitHubGetRepository>> getRepository({required String fullName});
+}
+
+// Implements
+
+class GitHubRepoRepository implements GitHubRepoRepositoryInterface {
+  final APIService apiService = APIService();
+
+  @override
+  Future<Result<GitHubGetRepository>> getRepository({required String fullName}) async {
+    final request = GetRepositoryRequest(fullName: fullName);
+    try {
+      final response = await apiService.sendRequest(request);
+      return Result.success(GitHubGetRepository.fromJson(json.decode(response.body)));
+    } catch(_) {
+      return Result.error(Error()); // TODO: change custom error type
+    }
+  }
+}

--- a/github_search/lib/repository/network/request/get_repository_request.dart
+++ b/github_search/lib/repository/network/request/get_repository_request.dart
@@ -1,0 +1,29 @@
+
+import 'package:github_search/utility/constant.dart';
+import 'package:github_search/repository/network/http_method.dart';
+import 'package:github_search/repository/network/request/request_interface.dart';
+
+// Reference
+// - doc: https://docs.github.com/ja/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
+
+class GetRepositoryRequest extends RequestInterface {
+  GetRepositoryRequest({required this.fullName});
+
+  final String fullName;
+
+  @override
+  String baseURL = Constant.githubBaseUrl;
+
+  @override
+  HTTPMethod method = HTTPMethod.get;
+
+  @override
+  String get path {
+    return "/repos/$fullName";
+  }
+
+  @override
+  Future<Map<String, String>?> parameters() async {
+    return null;
+  }
+}


### PR DESCRIPTION
## Purpose
<!-- _Describe the problem or feature in addition to a link to the issues._ -->

We cannot get `watchers_count` of the repository using Search API.
So, use the other api which is Get a repository API, use `subscribers_count` in that.

<img width=300 src="https://github.com/shusuke0812/flutter-engineer-codecheck/assets/33107697/0c684991-f320-4350-8159-c8a1a08aa5bd">

## Approach
<!-- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
- [x] Add Get a repository API request
- [x] Add Get a repository API response
- [x] Add Repository class
- [x] Add getting `subscribers_count` method in GitHubRepositoryDetailViewModel
- [x] Change setting watchers_count

## Learning
<!-- _Describe the research stage_ -->

<!-- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->

Nothing
